### PR TITLE
Show Change/Failure Rate on a 1-100% scale

### DIFF
--- a/Public/FourKeyMetricsTemplate.html
+++ b/Public/FourKeyMetricsTemplate.html
@@ -42,7 +42,7 @@
           );
           chart.draw(dataView, {
             title: data.getColumnLabel(colIndex),
-            vAxis: { title: vAxisTitle, format, minValue: 0 },
+            vAxis: { title: vAxisTitle, format, minValue: 0, maxValue: 1 },
             legend: { position: "none" },
             series: [{ color }],
             chartArea: { width: "80%", height: "80%" },


### PR DESCRIPTION
Zoom 'out' to show changes in Change Failure Rate in context (i.e. between 0 and 100 percent), rather than zooming in to give an overly pessimistic view.

**Before:**
![image](https://user-images.githubusercontent.com/8382756/67013950-e1ee9180-f0eb-11e9-8a80-187a7e41680e.png)

**After:**
![image](https://user-images.githubusercontent.com/8382756/67013923-d13e1b80-f0eb-11e9-9b7e-6a0090cdd4e5.png)

**Why may this be good?**
It supports the way we talk about Change Failure Rate - our current rates are quite low, and we're content with them. The current reporting view is quite melodramatic in comparison.

**Why may this be bad?**
The zoomed out nature of this change could make variances in Change Failure Rate harder to spot, since it'd be a smaller change ont he charts when generated.

**Caveats:**
Other reports are included above for testing/contextual purposes - they seem unchanged, because their datasets far outreach the new `maxValue`.

If any of the metrics drop below that `maxValue` of 1, they will see a similar zoomed-out view.

Since this is a trivial change, and that's not a problem we're facing right now, I'd suggest we handle that problem when it occurs (assuming we like this change!).