### PR TITLE
Clarify title on chart

### DIFF
--- a/Public/FourKeyMetricsTemplate.html
+++ b/Public/FourKeyMetricsTemplate.html
@@ -130,7 +130,7 @@
       </div>
 
       <div id="lead-time" class="chart">
-        <div class="title">Lead Time</div>
+        <div class="title">Delivery Lead Time</div>
         <div class="description">Each point in this chart shows the <em>mean</em> time taken for commits to be released to production over the preceding REPLACEWINDOWSIZE.</div>
         <div class="content"><!-- Placeholder that will be populated by the Google charts javascript --></div>
       </div>


### PR DESCRIPTION
I missed this while reviewing #4.

We should probably use the specific "Delivery Lead Time" term, rather than the looser "Lead Time"?