### PR TITLE
Update NuGet.CommandLine

### DIFF
--- a/.build/paket.dependencies
+++ b/.build/paket.dependencies
@@ -1,7 +1,7 @@
 source https://api.nuget.org/v3/index.json
 
 # You'll probably need nuget.exe in order to `nuget restore`, `nuget pack` and `nuget push`
-nuget Nuget.CommandLine ~> 3
+nuget NuGet.CommandLine ~> 5.5
 
 # https://github.com/nightroman/Invoke-Build
 # https://github.com/nightroman/Invoke-Build/wiki/Script-Tutorial


### PR DESCRIPTION
Older versions of NuGet.CommandLine have problems when running on build agents with newest Visual Studio – specifically NuGet 4.7 is incompatible with VS2019 16.5 – so it's important to keep NuGet up to date to ensure builds continue to work as build agents get upgraded.