### PR TITLE
Add a title and generated date to the report

### DIFF
--- a/Public/FourKeyMetricsTemplate.html
+++ b/Public/FourKeyMetricsTemplate.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8"/>
+    <title>Four Key Metrics for REPLACEREPO</title>
     <script
       type="text/javascript"
       src="https://www.gstatic.com/charts/loader.js"

--- a/Public/FourKeyMetricsTemplate.html
+++ b/Public/FourKeyMetricsTemplate.html
@@ -117,6 +117,14 @@
         grid-area: bottomright;
       }
 
+      #footer {
+        font-size: smaller;
+        color: lightgray;
+        position: fixed;
+        top: 0;
+        right: 0%;
+        padding-right: 1em;
+      }
     </style>
   </head>
 
@@ -154,5 +162,7 @@
         <div class="content"><!-- Placeholder that will be populated by the Google charts javascript --></div>
       </div>      
     </div>
+
+    <div id="footer">Generated on REPORTENDDATE</div>
   </body>
 </html>


### PR DESCRIPTION
## What has been done

I've added a page title and a generated date to the HTML report. I've done this by using the same substitution values that were already in use for the repository name and the end date.

## Why?

It's not obvious from the report when it was last generated.