### PR TITLE
Use the correct date for the generated date

### DIFF
--- a/Public/FourKeyMetricsTemplate.html
+++ b/Public/FourKeyMetricsTemplate.html
@@ -163,6 +163,6 @@
       </div>      
     </div>
 
-    <div id="footer">Generated on <script>document.write(REPORTENDDATE.toLocaleDateString())</script></div>
+    <div id="footer">Generated on <script>document.write(REPORTSTARTDATE.toLocaleDateString())</script></div>
   </body>
 </html>


### PR DESCRIPTION
## What has been done?

Fixed the generated date to use the correct date (fix for #8 and #9).

## Why?

It looks like the charts' dates are reversed, so the generated date is the start date from the chart, not the end date.

## How has it been tested?

I've manually checked that the start date is the date when the script is run.
