### PR TITLE
Only use the refname when matching tags, rather than using the tag name

### DIFF
--- a/Public/FourKeyMetrics.ps1
+++ b/Public/FourKeyMetrics.ps1
@@ -67,7 +67,13 @@ function Get-Releases($releaseTagPattern, $fixTagPattern ) {
 Get a list of all commits added to master between two release tags
 #>
 function Get-CommitsBetweenTags($start, $end, $subDirs) {
-    $rawCommits = git log --pretty=format:"%h,%ai" "$start..$end" --no-merges -- $subDirs
+    $gitCommand = "git log --pretty=format:`"%h,%ai`" `"$start..$end`" --no-merges -- $subDirs"
+    $rawCommits = Invoke-Expression $gitCommand
+
+    if ($LastExitCode -ne 0) {
+        throw "Exit code $LastExitCode returned by: $gitCommand"
+    }
+
     foreach ($commit in $rawCommits) {
         $split = $commit.Split(",")
         [PSCustomObject]@{

--- a/Public/FourKeyMetrics.ps1
+++ b/Public/FourKeyMetrics.ps1
@@ -41,7 +41,7 @@ function Get-AverageMetricsForPeriod($releaseMetrics, $endDate) {
 Identify a list of releases, based on repository data
 #>
 function Get-Releases($releaseTagPattern, $fixTagPattern ) {
-    $rawReleaseTags = (git for-each-ref --sort='-taggerdate' --format='%(tag),%(taggerdate:iso8601),%(refname),' "refs/tags/$releaseTagPattern")
+    $rawReleaseTags = (git for-each-ref --sort='-taggerdate' --format='%(taggerdate:iso8601),%(refname),' "refs/tags/$releaseTagPattern")
 
     if ($LastExitCode -ne 0){
         throw "Unable to analyse analysis root. Is the analysis root a git repository?"
@@ -50,14 +50,14 @@ function Get-Releases($releaseTagPattern, $fixTagPattern ) {
     foreach ($tag in $rawReleaseTags) {
         $split = $tag.Split(",")
         if ($split[0] -eq "") {
-            Write-Warning "Tag $($split[2]) is a light-weight tag and will be ignored"
+            Write-Warning "Tag $($split[1]) is a light-weight tag and will be ignored"
             continue
         }
 
         [PSCustomObject]@{
-            Tag   = $split[0];
-            Date  = [DateTime]::ParseExact($split[1], "yyyy-MM-dd HH:mm:ss zzz", $null);
-            IsFix = ($split[0] -like $fixTagPattern)
+            TagRef   = $split[1];
+            Date  = [DateTime]::ParseExact($split[0], "yyyy-MM-dd HH:mm:ss zzz", $null);
+            IsFix = ($split[1] -like "refs/tags/$fixTagPattern")
         }
     }
 }
@@ -83,8 +83,8 @@ function Get-CommitsBetweenTags($start, $end, $subDirs) {
     }
 }
 
-function Assert-ReleaseShouldBeConsidered($thisReleaseTag, $ignoreReleases) {
-    return !($ignoreReleases | Where-Object {$thisReleaseTag -Like $_})
+function Assert-ReleaseShouldBeConsidered($thisReleaseTagRef, $ignoreReleases) {
+    return !($ignoreReleases | Where-Object {$thisReleaseTagRef -Like "refs/tags/$_"})
 }
 
 <#
@@ -96,8 +96,8 @@ function Get-ReleaseMetrics($releases, $subDirs, $startDate, $ignoreReleases) {
     for ($i = 1; $i -lt $releases.Count; $i++) {
         $lastRelease = $releases[$i]
 
-        if (Assert-ReleaseShouldBeConsidered $ThisRelease.Tag $ignoreReleases) {
-            $commitAges = Get-CommitsBetweenTags $lastRelease.Tag $thisRelease.Tag $subDirs | Foreach-Object -Process { $thisRelease.Date - $_.Date } | Sort-Object
+        if (Assert-ReleaseShouldBeConsidered $ThisRelease.TagRef $ignoreReleases) {
+            $commitAges = Get-CommitsBetweenTags $lastRelease.TagRef $thisRelease.TagRef $subDirs | Foreach-Object -Process { $thisRelease.Date - $_.Date } | Sort-Object
             if ($commitAges.Count -gt 0) {
                 $mid = [Math]::Floor($commitAges.Count / 2)
                 $AverageCommitAge = $commitAges[$mid]
@@ -107,8 +107,8 @@ function Get-ReleaseMetrics($releases, $subDirs, $startDate, $ignoreReleases) {
             }
 
             [PSCustomObject]@{
-                From             = $lastRelease.Tag;
-                To               = $thisRelease.Tag;
+                From             = $lastRelease.TagRef;
+                To               = $thisRelease.TagRef;
                 FromDate         = $lastRelease.Date;
                 ToDate           = $thisRelease.Date;
                 Interval         = $thisRelease.Date - $lastRelease.Date;
@@ -384,9 +384,9 @@ function Measure-LeadTimeData {
     for ($i = 1; $i -lt $releases.Count; $i++) {
         $lastRelease = $releases[$i]
 
-        $commitsInRelease = git log --pretty=format:"%s" --grep="Merge pull request" "$($lastRelease.Tag)..$($thisRelease.Tag)"
+        $commitsInRelease = git log --pretty=format:"%s" --grep="Merge pull request" "$($lastRelease.TagRef)..$($thisRelease.TagRef)"
 
-        $message = "$($LastRelease.Tag) -> $($thisRelease.Tag) Released $($ThisRelease.Date)"
+        $message = "$($LastRelease.TagRef) -> $($thisRelease.TagRef) Released $($ThisRelease.Date)"
         Add-Content LeadTimeData.txt $message
         foreach ($commit in $commitsInRelease){
             Add-Content LeadTimeData.txt $commit

--- a/Tests/FourKeyMetrics.Tests.ps1
+++ b/Tests/FourKeyMetrics.Tests.ps1
@@ -171,7 +171,7 @@ Describe 'Assert-ReleaseShouldBeConsidered' {
         $ignoreReleases = @()
 
         It 'should return true for a given release' {
-            $val = Assert-ReleaseShouldBeConsidered "someTag" $ignoreReleases
+            $val = Assert-ReleaseShouldBeConsidered "refs/tags/someTag" $ignoreReleases
             $val | Should -Be $true
         }
     }
@@ -179,12 +179,12 @@ Describe 'Assert-ReleaseShouldBeConsidered' {
         $ignoreReleases = @("releaseToIgnore")
 
         It 'should return false for a the ignored release' {
-            $val = Assert-ReleaseShouldBeConsidered "releaseToIgnore" $ignoreReleases
+            $val = Assert-ReleaseShouldBeConsidered "refs/tags/releaseToIgnore" $ignoreReleases
             $val | Should -Be $false
         }
 
         It 'should return true for another release' {
-            $val = Assert-ReleaseShouldBeConsidered "someTag" $ignoreReleases
+            $val = Assert-ReleaseShouldBeConsidered "refs/tags/someTag" $ignoreReleases
             $val | Should -Be $true
         }
     }
@@ -192,12 +192,12 @@ Describe 'Assert-ReleaseShouldBeConsidered' {
         $ignoreReleases = @("releaseToIgnore", "anotherReleaseToIgnore")
 
         It 'should return false for an ignored release' {
-            $val = Assert-ReleaseShouldBeConsidered "anotherReleaseToIgnore" $ignoreReleases
+            $val = Assert-ReleaseShouldBeConsidered "refs/tags/anotherReleaseToIgnore" $ignoreReleases
             $val | Should -Be $false
         }
 
         It 'should return true for another release' {
-            $val = Assert-ReleaseShouldBeConsidered "someTag" $ignoreReleases
+            $val = Assert-ReleaseShouldBeConsidered "refs/tags/someTag" $ignoreReleases
             $val | Should -Be $true
         }
     }

--- a/Tests/FourKeyMetrics.Tests.ps1
+++ b/Tests/FourKeyMetrics.Tests.ps1
@@ -229,41 +229,41 @@ Describe 'Get-Releases' {
         }
     }
     Context 'Given one release' {
-        Mock git { return ("releases/5.0.3.1680,2019-06-11 12:11:25 +0100,refs/tags/releases/5.0.3.1680,")}
+        Mock git { return ("2019-06-11 12:11:25 +0100,refs/tags/releases/5.0.3.1680,")}
         $expectedDate = [DateTime]::ParseExact("2019-06-11 12:11:25 +0100", "yyyy-MM-dd HH:mm:ss zzz", $null);
 
         It 'should return a single release' {
             $releases = Get-Releases 'releaseTagPattern' 'fixtagPattern'
-            $releases.Tag | Should -Be "releases/5.0.3.1680"
+            $releases.TagRef | Should -Be "refs/tags/releases/5.0.3.1680"
             $releases.Date | Should -Be $expectedDate
             $releases.IsFix | Should -Be $false
         }
     }
     Context 'Given a hotfix release' {
-        Mock git { return ("releases/5.0.3.1680/fix,2019-06-11 12:11:25 +0100,refs/tags/releases/5.0.3.1680/fixx,")}
+        Mock git { return ("2019-06-11 12:11:25 +0100,refs/tags/releases/5.0.3.1680/fix")}
         $expectedDate = [DateTime]::ParseExact("2019-06-11 12:11:25 +0100", "yyyy-MM-dd HH:mm:ss zzz", $null);
 
         It 'should return a single hotfix release' {
             $releases = Get-Releases 'releaseTagPattern' 'releases/**/fix'
-            $releases.Tag | Should -Be "releases/5.0.3.1680/fix"
+            $releases.TagRef | Should -Be "refs/tags/releases/5.0.3.1680/fix"
             $releases.Date | Should -Be $expectedDate
             $releases.IsFix | Should -Be $true
         }
     }
     Context 'Given two releases' {
         Mock git { return (
-            "releases/5.0.3.1680,2019-06-11 12:11:25 +0100,refs/tags/releases/5.0.3.1680,",
-            "releases/5.0.2.1664,2019-06-03 10:34:37 +0100,refs/tags/releases/5.0.2.1664,")}
+            "2019-06-11 12:11:25 +0100,refs/tags/releases/5.0.3.1680,",
+            "2019-06-03 10:34:37 +0100,refs/tags/releases/5.0.2.1664,")}
         $firstExpectedDate = [DateTime]::ParseExact("2019-06-11 12:11:25 +0100", "yyyy-MM-dd HH:mm:ss zzz", $null);
         $secondExpectedDate = [DateTime]::ParseExact("2019-06-03 10:34:37 +0100", "yyyy-MM-dd HH:mm:ss zzz", $null);
 
         It 'should return a two releases, with the newest release first' {
             $releases = Get-Releases 'releaseTagPattern' 'fixtagPattern'
             $releases.Count | Should -Be 2
-            $releases[0].Tag | Should -Be "releases/5.0.3.1680"
+            $releases[0].TagRef | Should -Be "refs/tags/releases/5.0.3.1680"
             $releases[0].Date | Should -Be $firstExpectedDate
             $releases[0].IsFix | Should -Be $false
-            $releases[1].Tag | Should -Be "releases/5.0.2.1664"
+            $releases[1].TagRef | Should -Be "refs/tags/releases/5.0.2.1664"
             $releases[1].Date | Should -Be $secondExpectedDate
             $releases[1].IsFix | Should -Be $false
         }


### PR DESCRIPTION
We ran into an interesting glitch in one of our repos where the tag name reported by `git for-each-ref --sort='-taggerdate' --format='%(tag),%(taggerdate:iso8601),%(refname),' "refs/tags/$releaseTagPattern"` wasn't the same as the refname with a `refs/tags` prefix. The tag name wasn't actually valid to reference a commit, so git log failed later.

This PR removes the use of the tag name, and just uses refnames throughout, which removes the redundancy and potential error of using ref names in `git for-each-ref` but tag names in `git log`.

As a side thing, it also adds error handling to the `git log` call so that problems like this are easier to diagnose in the future.