### PR TITLE
Update mean to median for lead time

### DIFF
--- a/Public/FourKeyMetrics.ps1
+++ b/Public/FourKeyMetrics.ps1
@@ -162,13 +162,14 @@ function global:Get-ReleaseMetrics {
 
             $commitAges = Get-CommitsBetweenTags $lastRelease.TagRef $thisRelease.TagRef $subDirs | Foreach-Object -Process { $thisRelease.Date - $_.Date } | Sort-Object
             $numberOfCommitAges = $commitAges.Count
-            $evenNumberOfCommitAges = $numberOfCommitAges % 2 -eq 0;
 
             if ($numberOfCommitAges -gt 0) {
+
+                $evenNumberOfCommitAges = $numberOfCommitAges % 2 -eq 0;
+
                 if($evenNumberOfCommitAges) {
                     $midh = [Math]::Floor($numberOfCommitAges / 2)
-                    $midl = [Math]::Floor(($numberOfCommitAges - 1) / 2)
-                    $MedianCommitAge = New-TimeSpan -Minutes (($commitAges[$midl].TotalMinutes + $commitAges[$midh].TotalMinutes) / 2)
+                    $MedianCommitAge = New-TimeSpan -Minutes (($commitAges[$midh-1].TotalMinutes + $commitAges[$midh].TotalMinutes) / 2)
                 }
                 else {
                     $mid = [Math]::Floor($numberOfCommitAges / 2)

--- a/Public/FourKeyMetrics.ps1
+++ b/Public/FourKeyMetrics.ps1
@@ -159,10 +159,28 @@ function global:Get-ReleaseMetrics {
         $lastRelease = $releases[$i]
 
         if (Assert-ReleaseShouldBeConsidered $ThisRelease.TagRef $ignoreReleases) {
+
             $commitAges = Get-CommitsBetweenTags $lastRelease.TagRef $thisRelease.TagRef $subDirs | Foreach-Object -Process { $thisRelease.Date - $_.Date } | Sort-Object
-            if ($commitAges.Count -gt 0) {
-                $mid = [Math]::Floor($commitAges.Count / 2)
-                $MedianCommitAge = $commitAges[$mid]
+            $numberOfCommitAges = $commitAges.Count
+            $evenNumberOfCommitAges = $numberOfCommitAges % 2 -eq 0;
+
+            if ($numberOfCommitAges -gt 0) {
+                if($evenNumberOfCommitAges) {
+                    write-host "Even"
+                    $mid = [Math]::Floor($numberOfCommitAges / 2)
+                    $MedianCommitAge = $commitAges[$mid]
+                    write-host $MedianCommitAge
+                    
+
+                    $midh = [Math]::Floor($numberOfCommitAges / 2)
+                    $midl = [Math]::Floor(($numberOfCommitAges - 1) / 2)
+                    $MedianCommitAge = New-TimeSpan -Minutes (($commitAges[$midl].TotalMinutes + $commitAges[$midh].TotalMinutes) / 2)
+                    write-host $MedianCommitAge
+                }
+                else {
+                    $mid = [Math]::Floor($numberOfCommitAges / 2)
+                    $MedianCommitAge = $commitAges[$mid]
+                }
             }
             else {
                 $MedianCommitAge = $null;

--- a/Public/FourKeyMetrics.ps1
+++ b/Public/FourKeyMetrics.ps1
@@ -162,10 +162,10 @@ function global:Get-ReleaseMetrics {
             $commitAges = Get-CommitsBetweenTags $lastRelease.TagRef $thisRelease.TagRef $subDirs | Foreach-Object -Process { $thisRelease.Date - $_.Date } | Sort-Object
             if ($commitAges.Count -gt 0) {
                 $mid = [Math]::Floor($commitAges.Count / 2)
-                $AverageCommitAge = $commitAges[$mid]
+                $MedianCommitAge = $commitAges[$mid]
             }
             else {
-                $AverageCommitAge = $null;
+                $MedianCommitAge = $null;
             }
 
             [PSCustomObject]@{
@@ -175,7 +175,7 @@ function global:Get-ReleaseMetrics {
                 ToDate           = $thisRelease.Date;
                 Interval         = $thisRelease.Date - $lastRelease.Date;
                 IsFix            = $thisRelease.IsFix;
-                AverageCommitAge = $AverageCommitAge;
+                MedianCommitAge = $MedianCommitAge;
             }
         }
 
@@ -246,7 +246,7 @@ function Get-AverageMetricsForPeriod($releaseMetrics, $endDate) {
     if ($releaseCount -gt 0){
         $deploymentFrequencyDays = ($releaseMetrics | ForEach-Object {$_.Interval.TotalDays} | Measure-Object -Average).Average;
         $failRate = $failedreleaseCount / $releaseCount
-        $leadTimeMeasures = $releaseMetrics | Where-Object {$null -ne $_.AverageCommitAge } | ForEach-Object { $_.AverageCommitAge.TotalDays } | Measure-Object -Average
+        $leadTimeMeasures = $releaseMetrics | Where-Object {$null -ne $_.MedianCommitAge } | ForEach-Object { $_.MedianCommitAge.TotalDays } | Measure-Object -Average
         $leadTimeAverage = $leadTimeMeasures.Average;
     }
     else {

--- a/Public/FourKeyMetrics.ps1
+++ b/Public/FourKeyMetrics.ps1
@@ -166,16 +166,9 @@ function global:Get-ReleaseMetrics {
 
             if ($numberOfCommitAges -gt 0) {
                 if($evenNumberOfCommitAges) {
-                    write-host "Even"
-                    $mid = [Math]::Floor($numberOfCommitAges / 2)
-                    $MedianCommitAge = $commitAges[$mid]
-                    write-host $MedianCommitAge
-                    
-
                     $midh = [Math]::Floor($numberOfCommitAges / 2)
                     $midl = [Math]::Floor(($numberOfCommitAges - 1) / 2)
                     $MedianCommitAge = New-TimeSpan -Minutes (($commitAges[$midl].TotalMinutes + $commitAges[$midh].TotalMinutes) / 2)
-                    write-host $MedianCommitAge
                 }
                 else {
                     $mid = [Math]::Floor($numberOfCommitAges / 2)

--- a/Public/FourKeyMetricsTemplate.html
+++ b/Public/FourKeyMetricsTemplate.html
@@ -141,7 +141,7 @@
 
       <div id="lead-time" class="chart">
         <div class="title">Delivery Lead Time</div>
-        <div class="description">Each point in this chart shows the <em>mean</em> time taken for commits to be released to production over the preceding WINDOWSIZE_PLACEHOLDER.</div>
+        <div class="description">Each point in this chart shows the <em>mean</em> of the <em>median</em> time taken for commits to be released to production over the preceding WINDOWSIZE_PLACEHOLDER.</div>
         <div class="content"><!-- Placeholder that will be populated by the Google charts javascript --></div>
       </div>
       

--- a/Public/FourKeyMetricsTemplate.html
+++ b/Public/FourKeyMetricsTemplate.html
@@ -141,7 +141,7 @@
 
       <div id="lead-time" class="chart">
         <div class="title">Delivery Lead Time</div>
-        <div class="description">Each point in this chart shows the <em>mean</em> of the <em>median</em> time taken for commits to be released to production over the preceding WINDOWSIZE_PLACEHOLDER.</div>
+        <div class="description">Each point in this chart shows the <em>mean</em> of the <em>median</em> time taken for commits for a release to be released to production over the preceding WINDOWSIZE_PLACEHOLDER.</div>
         <div class="content"><!-- Placeholder that will be populated by the Google charts javascript --></div>
       </div>
       

--- a/Tests/FourKeyMetrics.Tests.ps1
+++ b/Tests/FourKeyMetrics.Tests.ps1
@@ -28,7 +28,7 @@ Describe 'Get-AverageMetricsForPeriod' {
             ToDate          = [DateTime]"2019-05-17";
             Interval        = New-Timespan -D 14;
             IsFix           = $false;
-            AverageCommitAge = New-Timespan -H 24;
+            MedianCommitAge = New-Timespan -H 24;
         }
     
         $releases = @($release)
@@ -68,7 +68,7 @@ Describe 'Get-AverageMetricsForPeriod' {
             ToDate          = [DateTime]"2019-05-21"
             Interval        = New-Timespan -D 4;
             IsFix           = $true;
-            AverageCommitAge = New-Timespan -H 24;
+            MedianCommitAge = New-Timespan -H 24;
         }
         
         $releaseOne = [PSCustomObject]@{
@@ -78,7 +78,7 @@ Describe 'Get-AverageMetricsForPeriod' {
             ToDate          = [DateTime]"2019-05-17"
             Interval        = New-Timespan -D 1;
             IsFix           = $false;
-            AverageCommitAge = New-Timespan -H 24;
+            MedianCommitAge = New-Timespan -H 24;
         }
     
         $releases = @($releaseTwo, $releaseOne)
@@ -108,7 +108,7 @@ Describe 'Get-AverageReleaseMetrics' {
                 ToDate          = [DateTime]"2019-05-13"
                 Interval        = New-Timespan -D 42;
                 IsFix           = $false;
-                AverageCommitAge = New-Timespan -D 20;},
+                MedianCommitAge = New-Timespan -D 20;},
             [PSCustomObject]@{
                 From            = "releases/0.1";
                 To              = "releases/0.2";
@@ -116,7 +116,7 @@ Describe 'Get-AverageReleaseMetrics' {
                 ToDate          = [DateTime]"2019-05-21"
                 Interval        = New-Timespan -D 8;
                 IsFix           = $false;
-                AverageCommitAge = New-Timespan -D 3.5;},
+                MedianCommitAge = New-Timespan -D 3.5;},
             [PSCustomObject]@{
                 From            = "releases/0.2";
                 To              = "releases/0.3/fix";
@@ -124,7 +124,7 @@ Describe 'Get-AverageReleaseMetrics' {
                 ToDate          = [DateTime]"2019-05-22"
                 Interval        = New-Timespan -D 1;
                 IsFix           = $true;
-                AverageCommitAge = New-Timespan -D 0.5;},
+                MedianCommitAge = New-Timespan -D 0.5;},
             [PSCustomObject]@{
                 From            = "releases/0.3/fix";
                 To              = "releases/0.4";
@@ -132,7 +132,7 @@ Describe 'Get-AverageReleaseMetrics' {
                 ToDate          = [DateTime]"2019-05-28"
                 Interval        = New-Timespan -D 6;
                 IsFix           = $false;
-                AverageCommitAge = New-Timespan -D 2;},
+                MedianCommitAge = New-Timespan -D 2;},
             [PSCustomObject]@{
                 From            = "releases/0.4";
                 To              = "releases/0.5";
@@ -140,7 +140,7 @@ Describe 'Get-AverageReleaseMetrics' {
                 ToDate          = [DateTime]"2019-06-04"
                 Interval        = New-Timespan -D 7;
                 IsFix           = $false;
-                AverageCommitAge = New-Timespan -D 4;}
+                MedianCommitAge = New-Timespan -D 4;}
             );        
 
         Mock Get-Date { return [DateTime]"2019-06-07"}


### PR DESCRIPTION
Looking at the code, I see that we aren't always clear about means and medians in the results. 

The lead time, for example, is calculated by taking the commits that go in to the release and calculating the median of the timespan between the commit being created and the release being created. The variable in the code contains the word Average (implying mean), but it holds the median of the values.

This PR does three things
- renames the variable to Median
- calculates the median of an even number of items by taking the average (mid-point) of the two middle items
- changes the text on the graph to say that we take the mean (across the items in the bucket) of the medians of the lead times. Previously it just mentioned the mean, so I always assumed it was the mean of the mean of the time from commit create and the create for the release containing the commit - the values in the graphs looked wrong with that interpretation.

Old tag line:

![image](https://github.com/red-gate/RedGate.Metrics/assets/2143508/71ad9ac6-7797-4ae4-9d9f-05cea35df5b4)

New tag line:

![image](https://github.com/red-gate/RedGate.Metrics/assets/2143508/c176e371-239c-4b43-881c-1a5fe28f9f70)


I tested by plotting the old and new graphs for Sql Monitor - the numbers change for some rows in the generated html file, but the graphs look the same - I think that is because I `fixed` the median of an even number of items calculation.

I think there is more work to do. Looking at https://github.com/dora-team/fourkeys/blob/main/METRICS.md, an implementation by the DORA team, they tend to use medians rather than means across the buckets in a number of their calculations (eq https://github.com/dora-team/fourkeys/blob/main/METRICS.md#calculating-the-bucket-1 ) where I think we take the medians and then average them. I could be wrong and haven't had time to look in more details, but will come back to this.