### PR TITLE
Don't take mean of the medians

### DIFF
--- a/Public/FourKeyMetrics.ps1
+++ b/Public/FourKeyMetrics.ps1
@@ -226,7 +226,7 @@ function global:Get-BucketedReleaseMetricsForReport {
         $startDate = $endDate.AddDays(-$windowSizeDays)
         $lookbackReleases = @($releaseMetrics | Where-Object { $_.ToDate -ge $startDate -AND $_.ToDate -le $endDate })
 
-        Get-MetricsForPeriod $lookbackReleases $endDate
+        Get-BucketedMetricsForPeriod $lookbackReleases $endDate
     }
 }
 
@@ -234,7 +234,7 @@ function global:Get-BucketedReleaseMetricsForReport {
 .SYNOPSIS
 Calculate bucketed values for the Four Key Metrics, based on a provided set of releases
 #>
-function Get-MetricsForPeriod($releaseMetrics, $endDate) {
+function Get-BucketedMetricsForPeriod($releaseMetrics, $endDate) {
     $releaseCount = $releaseMetrics.Count
     $failedReleaseCount = @($releaseMetrics | Where-Object { $_.IsFix }).Count
 

--- a/Public/FourKeyMetrics.ps1
+++ b/Public/FourKeyMetrics.ps1
@@ -3,7 +3,7 @@
 Build and publish a new Four Key Metrics report
 
 .DESCRIPTION
-Facade around Get-ReleaseMetricsForCheckout, Get-BucketedReleaseMetricsForReport, New-FourKetMetricsReport, and Publish-FourKeyMetricsReport
+Facade around Get-ReleaseMetricsForCheckout, Get-BucketedReleaseMetricsForReport, New-FourKeyMetricsReport, and Publish-FourKeyMetricsReport
 
 #>
 function global:Invoke-FourKeyMetricsReportGeneration {

--- a/Public/FourKeyMetrics.ps1
+++ b/Public/FourKeyMetrics.ps1
@@ -160,7 +160,7 @@ function global:Get-ReleaseMetrics {
 
         if (Assert-ReleaseShouldBeConsidered $ThisRelease.TagRef $ignoreReleases) {
 
-            $CommitAges = Get-CommitsBetweenTags $lastRelease.TagRef $thisRelease.TagRef $subDirs | Foreach-Object -Process { $thisRelease.Date - $_.Date } | Sort-Object
+            $CommitAges = Get-CommitsBetweenTags $lastRelease.TagRef $thisRelease.TagRef $subDirs | Foreach-Object -Process { $thisRelease.Date - $_.Date } 
         }
         else {
             

--- a/Public/FourKeyMetrics.ps1
+++ b/Public/FourKeyMetrics.ps1
@@ -54,13 +54,13 @@ function global:Invoke-FourKeyMetricsReportGeneration {
         -lookbackMonths $LookbackMonths `
         -ignoreReleases $ignoreReleases
 
-    $averageReleaseMetrics = Get-ReleaseMetricsForReport `
+    $bucketedReleaseMetrics = Get-ReleaseMetricsForReport `
         -lookbackMonths $LookbackMonths `
         -releaseMetrics $releaseMetrics `
         -windowSizeDays $WindowSizeDays `
         -windowIntervalDays $WindowIntervalDays
 
-    $reportFile = New-FourKeyMetricsReport -metrics $averageReleaseMetrics -productName $ProductName -outFilePath $OutFilePath -windowSize "$windowSizeDays days" -OutFileName $outFileName
+    $reportFile = New-FourKeyMetricsReport -metrics $bucketedReleaseMetrics -productName $ProductName -outFilePath $OutFilePath -windowSize "$windowSizeDays days" -OutFileName $outFileName
 
     if (PublishCredentialsProvided($OctopusFeedApiKey, $ReportPackageName, $ReportVersionNumber)) {
         Publish-FourKeyMetricsReport -reportFile $reportFile -packageName $ReportPackageName -octopusFeedApiKey $OctopusFeedApiKey -versionNumber $ReportVersionNumber

--- a/Public/FourKeyMetrics.ps1
+++ b/Public/FourKeyMetrics.ps1
@@ -51,7 +51,6 @@ function global:Invoke-FourKeyMetricsReportGeneration {
         -fixTagPattern $FixTagPattern `
         -startDate $StartDate `
         -repoSubDirs $RepoSubDirs `
-        -lookbackMonths $LookbackMonths `
         -ignoreReleases $ignoreReleases
 
     $bucketedReleaseMetrics = Get-ReleaseMetricsForReport `
@@ -93,8 +92,6 @@ function global:Get-ReleaseMetricsForCheckout {
         [datetime]$startDate,
         # Optional, case sensitive. Filters commits to a particular set of sub directories for use in mono-repos
         [string[]]$repoSubDirs = @(""),
-        # Optional. How many months back to report on
-        [int]$lookbackMonths = 12,
         # Optional. Release/s to exclude from lead time analysis
         [string[]] $ignoreReleases = @("")
     )

--- a/Public/FourKeyMetrics.ps1
+++ b/Public/FourKeyMetrics.ps1
@@ -245,9 +245,7 @@ function Get-MetricsForPeriod($releaseMetrics, $endDate) {
         $deploymentFrequencyDays = ($releaseMetrics | ForEach-Object {$_.Interval.TotalDays} | Measure-Object -Average).Average;
         $failRate = $failedreleaseCount / $releaseCount
 
-        $orderedLeadTimes = $releaseMetrics | Where-Object {$null -ne $_.CommitAges } | % { $_.CommitAges } | Sort-Object;
-        write-host $orderedLeadTimes.Count
-       
+        $orderedLeadTimes = $releaseMetrics | Where-Object {$null -ne $_.CommitAges } | % { $_.CommitAges } | Sort-Object;       
         $numberOfCommitAges = $orderedLeadTimes.Count
 
         if ($numberOfCommitAges -gt 0) {

--- a/Public/FourKeyMetrics.ps1
+++ b/Public/FourKeyMetrics.ps1
@@ -3,7 +3,7 @@
 Build and publish a new Four Key Metrics report
 
 .DESCRIPTION
-Facade around Get-ReleaseMetricsForCheckout, Get-AverageReleaseMetrics, New-FourKetMetricsReport, and Publish-FourKeyMetricsReport
+Facade around Get-ReleaseMetricsForCheckout, Get-ReleaseMetrics, New-FourKetMetricsReport, and Publish-FourKeyMetricsReport
 
 #>
 function global:Invoke-FourKeyMetricsReportGeneration {
@@ -54,7 +54,7 @@ function global:Invoke-FourKeyMetricsReportGeneration {
         -lookbackMonths $LookbackMonths `
         -ignoreReleases $ignoreReleases
 
-    $averageReleaseMetrics = Get-AverageReleaseMetrics `
+    $averageReleaseMetrics = Get-ReleaseMetrics `
         -lookbackMonths $LookbackMonths `
         -releaseMetrics $releaseMetrics `
         -windowSizeDays $WindowSizeDays `
@@ -210,7 +210,7 @@ function Get-CommitsBetweenTags($start, $end, $subDirs) {
     }
 }
 
-function global:Get-AverageReleaseMetrics {
+function global:Get-ReleaseMetrics {
     [CmdletBinding()]
     param(
         # Pre-processed release metrics

--- a/Public/FourKeyMetrics.ps1
+++ b/Public/FourKeyMetrics.ps1
@@ -3,7 +3,7 @@
 Build and publish a new Four Key Metrics report
 
 .DESCRIPTION
-Facade around Get-ReleaseMetricsForCheckout, Get-ReleaseMetrics, New-FourKetMetricsReport, and Publish-FourKeyMetricsReport
+Facade around Get-ReleaseMetricsForCheckout, Get-ReleaseMetricsForReport, New-FourKetMetricsReport, and Publish-FourKeyMetricsReport
 
 #>
 function global:Invoke-FourKeyMetricsReportGeneration {
@@ -54,7 +54,7 @@ function global:Invoke-FourKeyMetricsReportGeneration {
         -lookbackMonths $LookbackMonths `
         -ignoreReleases $ignoreReleases
 
-    $averageReleaseMetrics = Get-ReleaseMetrics `
+    $averageReleaseMetrics = Get-ReleaseMetricsForReport `
         -lookbackMonths $LookbackMonths `
         -releaseMetrics $releaseMetrics `
         -windowSizeDays $WindowSizeDays `
@@ -210,7 +210,7 @@ function Get-CommitsBetweenTags($start, $end, $subDirs) {
     }
 }
 
-function global:Get-ReleaseMetrics {
+function global:Get-ReleaseMetricsForReport {
     [CmdletBinding()]
     param(
         # Pre-processed release metrics

--- a/Public/FourKeyMetrics.ps1
+++ b/Public/FourKeyMetrics.ps1
@@ -244,26 +244,8 @@ function Get-MetricsForPeriod($releaseMetrics, $endDate) {
     if ($releaseCount -gt 0){
         $deploymentFrequencyDays = ($releaseMetrics | ForEach-Object {$_.Interval.TotalDays} | Measure-Object -Average).Average;
         $failRate = $failedreleaseCount / $releaseCount
-
-        $orderedLeadTimes = $releaseMetrics | Where-Object {$null -ne $_.CommitAges } | % { $_.CommitAges } | Sort-Object;       
-        $numberOfCommitAges = $orderedLeadTimes.Count
-
-        if ($numberOfCommitAges -gt 0) {
-
-            $evenNumberOfCommitAges = $numberOfCommitAges % 2 -eq 0;
-
-            if($evenNumberOfCommitAges) {
-                $midh = [Math]::Floor($numberOfCommitAges / 2)
-                $leadTimeMedian = ($orderedLeadTimes[$midh-1].TotalDays + $orderedLeadTimes[$midh].TotalDays) / 2
-            }
-            else {
-                $mid = [Math]::Floor($numberOfCommitAges / 2)
-                $leadTimeMedian = $orderedLeadTimes[$mid].TotalDays
-
-            }}
-            else {
-                $leadTimeMedian = $null
-            }
+        $leadTimes = $releaseMetrics | Where-Object {$null -ne $_.CommitAges } | % { $_.CommitAges };
+        $leadTimeMedian = Get-Median($leadTimes)       
     }
     else {
         $deploymentFrequencyDays = $null;
@@ -287,6 +269,28 @@ function Get-MetricsForPeriod($releaseMetrics, $endDate) {
         LeadTimeDays            = $leadTimeMedian;
         FailRate                = $failRate;
     }
+}
+
+function global:Get-Median($leadTimes){
+    $orderedLeadTimes = $leadTimes | Sort-Object;       
+    $numberOfCommitAges = $orderedLeadTimes.Count
+
+    if ($numberOfCommitAges -gt 0) {
+
+        $evenNumberOfCommitAges = $numberOfCommitAges % 2 -eq 0;
+
+        if($evenNumberOfCommitAges) {
+            $midh = [Math]::Floor($numberOfCommitAges / 2)
+            return ($orderedLeadTimes[$midh-1].TotalDays + $orderedLeadTimes[$midh].TotalDays) / 2
+        }
+        else {
+            $mid = [Math]::Floor($numberOfCommitAges / 2)
+            return $orderedLeadTimes[$mid].TotalDays
+
+        }}
+        else {
+            return $null
+        }
 }
 
 <#

--- a/Public/FourKeyMetrics.ps1
+++ b/Public/FourKeyMetrics.ps1
@@ -3,7 +3,7 @@
 Build and publish a new Four Key Metrics report
 
 .DESCRIPTION
-Facade around Get-ReleaseMetricsForCheckout, Get-ReleaseMetricsForReport, New-FourKetMetricsReport, and Publish-FourKeyMetricsReport
+Facade around Get-ReleaseMetricsForCheckout, Get-BucketedReleaseMetricsForReport, New-FourKetMetricsReport, and Publish-FourKeyMetricsReport
 
 #>
 function global:Invoke-FourKeyMetricsReportGeneration {
@@ -53,7 +53,7 @@ function global:Invoke-FourKeyMetricsReportGeneration {
         -repoSubDirs $RepoSubDirs `
         -ignoreReleases $ignoreReleases
 
-    $bucketedReleaseMetrics = Get-ReleaseMetricsForReport `
+    $bucketedReleaseMetrics = Get-BucketedReleaseMetricsForReport `
         -lookbackMonths $LookbackMonths `
         -releaseMetrics $releaseMetrics `
         -windowSizeDays $WindowSizeDays `
@@ -207,7 +207,7 @@ function Get-CommitsBetweenTags($start, $end, $subDirs) {
     }
 }
 
-function global:Get-ReleaseMetricsForReport {
+function global:Get-BucketedReleaseMetricsForReport {
     [CmdletBinding()]
     param(
         # Pre-processed release metrics

--- a/Public/FourKeyMetrics.ps1
+++ b/Public/FourKeyMetrics.ps1
@@ -272,14 +272,15 @@ function Get-MetricsForPeriod($releaseMetrics, $endDate) {
 }
 
 function global:Get-Median($leadTimes){
+    
     $orderedLeadTimes = $leadTimes | Sort-Object;       
     $numberOfCommitAges = $orderedLeadTimes.Count
 
     if ($numberOfCommitAges -gt 0) {
 
-        $evenNumberOfCommitAges = $numberOfCommitAges % 2 -eq 0;
+        $isEvenNumberOfCommitAges = $numberOfCommitAges % 2 -eq 0;
 
-        if($evenNumberOfCommitAges) {
+        if($isEvenNumberOfCommitAges) {
             $midh = [Math]::Floor($numberOfCommitAges / 2)
             return ($orderedLeadTimes[$midh-1].TotalDays + $orderedLeadTimes[$midh].TotalDays) / 2
         }
@@ -287,10 +288,10 @@ function global:Get-Median($leadTimes){
             $mid = [Math]::Floor($numberOfCommitAges / 2)
             return $orderedLeadTimes[$mid].TotalDays
 
-        }}
-        else {
-            return $null
         }
+    }
+
+    return $null
 }
 
 <#

--- a/Public/FourKeyMetricsTemplate.html
+++ b/Public/FourKeyMetricsTemplate.html
@@ -141,7 +141,7 @@
 
       <div id="lead-time" class="chart">
         <div class="title">Delivery Lead Time</div>
-        <div class="description">Each point in this chart shows the <em>mean</em> of the <em>median</em> time taken for commits for a release to be released to production over the preceding WINDOWSIZE_PLACEHOLDER.</div>
+        <div class="description">Each point in this chart shows the <em>median</em> time taken for commits for a release to be released to production over the preceding WINDOWSIZE_PLACEHOLDER.</div>
         <div class="content"><!-- Placeholder that will be populated by the Google charts javascript --></div>
       </div>
       

--- a/Tests/FourKeyMetrics.Tests.ps1
+++ b/Tests/FourKeyMetrics.Tests.ps1
@@ -98,7 +98,7 @@ Describe 'Get-MetricsForPeriod' {
     }
 }
 
-Describe 'Get-AverageReleaseMetrics' {
+Describe 'Get-ReleaseMetrics' {
     Context 'Given multiple releases, a lookback period of 1 month, a window size of 14 days, and a window interval of 7 days' {
         $releases = @(
             [PSCustomObject]@{
@@ -145,7 +145,7 @@ Describe 'Get-AverageReleaseMetrics' {
 
         Mock Get-Date { return [DateTime]"2019-06-07"}
 
-        $metrics = Get-AverageReleaseMetrics $releases -lookbackMonths 1 -windowSizeDays 14 -windowIntervalDays 7 | Sort-Object -Property EndDate -Descending
+        $metrics = Get-ReleaseMetrics $releases -lookbackMonths 1 -windowSizeDays 14 -windowIntervalDays 7 | Sort-Object -Property EndDate -Descending
 
         It 'should provide results for windows going back for a month at 7 day intervals starting at the current date' {
             $metrics | ForEach-Object { $_.EndDate } | Should -Be @(

--- a/Tests/FourKeyMetrics.Tests.ps1
+++ b/Tests/FourKeyMetrics.Tests.ps1
@@ -126,7 +126,7 @@ Describe 'Get-MetricsForPeriod' {
     }
 }
 
-Describe 'Get-ReleaseMetricsForReport' {
+Describe 'Get-BucketedReleaseMetricsForReport' {
     Context 'Given multiple releases, a lookback period of 1 month, a window size of 14 days, and a window interval of 7 days' {
         $releases = @(
             [PSCustomObject]@{
@@ -173,7 +173,7 @@ Describe 'Get-ReleaseMetricsForReport' {
 
         Mock Get-Date { return [DateTime]"2019-06-07"}
 
-        $metrics = Get-ReleaseMetricsForReport $releases -lookbackMonths 1 -windowSizeDays 14 -windowIntervalDays 7 | Sort-Object -Property EndDate -Descending
+        $metrics = Get-BucketedReleaseMetricsForReport $releases -lookbackMonths 1 -windowSizeDays 14 -windowIntervalDays 7 | Sort-Object -Property EndDate -Descending
 
         It 'should provide results for windows going back for a month at 7 day intervals starting at the current date' {
             $metrics | ForEach-Object { $_.EndDate } | Should -Be @(

--- a/Tests/FourKeyMetrics.Tests.ps1
+++ b/Tests/FourKeyMetrics.Tests.ps1
@@ -126,7 +126,7 @@ Describe 'Get-MetricsForPeriod' {
     }
 }
 
-Describe 'Get-ReleaseMetrics' {
+Describe 'Get-ReleaseMetricsForReport' {
     Context 'Given multiple releases, a lookback period of 1 month, a window size of 14 days, and a window interval of 7 days' {
         $releases = @(
             [PSCustomObject]@{
@@ -173,7 +173,7 @@ Describe 'Get-ReleaseMetrics' {
 
         Mock Get-Date { return [DateTime]"2019-06-07"}
 
-        $metrics = Get-ReleaseMetrics $releases -lookbackMonths 1 -windowSizeDays 14 -windowIntervalDays 7 | Sort-Object -Property EndDate -Descending
+        $metrics = Get-ReleaseMetricsForReport $releases -lookbackMonths 1 -windowSizeDays 14 -windowIntervalDays 7 | Sort-Object -Property EndDate -Descending
 
         It 'should provide results for windows going back for a month at 7 day intervals starting at the current date' {
             $metrics | ForEach-Object { $_.EndDate } | Should -Be @(

--- a/Tests/FourKeyMetrics.Tests.ps1
+++ b/Tests/FourKeyMetrics.Tests.ps1
@@ -2,6 +2,34 @@
 
 . ../Public/FourKeyMetrics.ps1
 
+Describe 'Check median calculations' {
+    Context 'Misc Tests' {
+            It 'should work for 2 ordered values' {
+                $median = Get-Median @(New-TimeSpan -days 1; New-TimeSpan -days 2)
+                $median | Should -Be 1.5 
+            }
+            It 'should work for 2 unordered values' {
+                $median = Get-Median @(New-TimeSpan -days 2; New-TimeSpan -days 1)
+                $median | Should -Be 1.5 
+            }
+            It 'should work for 3 ordered values' {
+                $median = Get-Median @(New-TimeSpan -D 1; New-TimeSpan -D 2; New-TimeSpan -D 3)
+                $median | Should -Be 2
+            }
+            It 'should work for 3 unordered values' {
+                $median = Get-Median @(New-TimeSpan -D 2; New-TimeSpan -D 3; New-TimeSpan -D 1)
+                $median | Should -Be 2
+            }
+            It 'should work for 4 ordered values' {
+                $median = Get-Median @(New-TimeSpan -D 1; New-TimeSpan -D 2; New-TimeSpan -D 3; ; New-TimeSpan -D 4)
+                $median | Should -Be 2.5
+            }
+            It 'should work for 4 unordered values' {
+                $median = Get-Median @(New-TimeSpan -D 2; New-TimeSpan -D 4; New-TimeSpan -D 3; New-TimeSpan -D 1)
+                $median | Should -Be 2.5
+            }
+    }
+}
 Describe 'Get-MetricsForPeriod' {
     Context 'Given no releases' {
         $releases = @()

--- a/Tests/FourKeyMetrics.Tests.ps1
+++ b/Tests/FourKeyMetrics.Tests.ps1
@@ -2,13 +2,13 @@
 
 . ../Public/FourKeyMetrics.ps1
 
-Describe 'Get-AverageMetricsForPeriod' {
+Describe 'Get-MetricsForPeriod' {
     Context 'Given no releases' {
         $releases = @()
 
         $endDate = [DateTime]"2019-05-21";
 
-        $averageMetrics = Get-AverageMetricsForPeriod $releases $endDate
+        $averageMetrics = Get-MetricsForPeriod $releases $endDate
 
         It 'should return an empty set of metrics' {
             $averageMetrics.Releases | Should -Be "0" # Explicitly provide zero releases
@@ -36,7 +36,7 @@ Describe 'Get-AverageMetricsForPeriod' {
         It 'should return average metrics equal to the metrics of that release' {
             $endDate = [DateTime]"2019-05-17"
 
-            $averageMetrics = Get-AverageMetricsForPeriod $releases $endDate
+            $averageMetrics = Get-MetricsForPeriod $releases $endDate
 
             $averageMetrics.Releases | Should -Be "1" # Explicitly provide one release
             $averageMetrics.DeploymentFrequencyDays | Should -Be "14" # Only 1 release, so the deployment frequency should be the same as the release interval
@@ -49,7 +49,7 @@ Describe 'Get-AverageMetricsForPeriod' {
         It 'should not degrade the deployment frequency as time passes' {
             $endDate = [DateTime]"2019-05-21"
 
-            $averageMetrics = Get-AverageMetricsForPeriod $releases $endDate
+            $averageMetrics = Get-MetricsForPeriod $releases $endDate
 
             $averageMetrics.Releases | Should -Be "1" # Explicitly provide one release
             $averageMetrics.DeploymentFrequencyDays | Should -Be "14" # Only 1 release, so the deployment frequency should be the same as the release interval
@@ -68,7 +68,7 @@ Describe 'Get-AverageMetricsForPeriod' {
             ToDate          = [DateTime]"2019-05-21"
             Interval        = New-Timespan -D 4;
             IsFix           = $true;
-            MedianCommitAge = New-Timespan -H 24;
+            CommitAges      = @(New-Timespan -H 24);
         }
         
         $releaseOne = [PSCustomObject]@{
@@ -78,14 +78,14 @@ Describe 'Get-AverageMetricsForPeriod' {
             ToDate          = [DateTime]"2019-05-17"
             Interval        = New-Timespan -D 1;
             IsFix           = $false;
-            MedianCommitAge = New-Timespan -H 24;
+            CommitAges      = @(New-Timespan -H 24);
         }
     
         $releases = @($releaseTwo, $releaseOne)
 
         $endDate = [DateTime]"2019-05-21"
 
-        $averageMetrics = Get-AverageMetricsForPeriod $releases $endDate
+        $averageMetrics = Get-MetricsForPeriod $releases $endDate
 
         It 'should calculate the correct average metrics' {
             $averageMetrics.Releases | Should -Be "2" # Explicitly provide two releases
@@ -108,7 +108,7 @@ Describe 'Get-AverageReleaseMetrics' {
                 ToDate          = [DateTime]"2019-05-13"
                 Interval        = New-Timespan -D 42;
                 IsFix           = $false;
-                MedianCommitAge = New-Timespan -D 20;},
+                CommitAges      = @(New-Timespan -D 20);},
             [PSCustomObject]@{
                 From            = "releases/0.1";
                 To              = "releases/0.2";
@@ -116,7 +116,7 @@ Describe 'Get-AverageReleaseMetrics' {
                 ToDate          = [DateTime]"2019-05-21"
                 Interval        = New-Timespan -D 8;
                 IsFix           = $false;
-                MedianCommitAge = New-Timespan -D 3.5;},
+                CommitAges      = @(New-Timespan -D 3.5);},
             [PSCustomObject]@{
                 From            = "releases/0.2";
                 To              = "releases/0.3/fix";
@@ -124,7 +124,7 @@ Describe 'Get-AverageReleaseMetrics' {
                 ToDate          = [DateTime]"2019-05-22"
                 Interval        = New-Timespan -D 1;
                 IsFix           = $true;
-                MedianCommitAge = New-Timespan -D 0.5;},
+                CommitAges      = @(New-Timespan -D 0.5);},
             [PSCustomObject]@{
                 From            = "releases/0.3/fix";
                 To              = "releases/0.4";
@@ -132,7 +132,7 @@ Describe 'Get-AverageReleaseMetrics' {
                 ToDate          = [DateTime]"2019-05-28"
                 Interval        = New-Timespan -D 6;
                 IsFix           = $false;
-                MedianCommitAge = New-Timespan -D 2;},
+                CommitAges      = @(New-Timespan -D 2);},
             [PSCustomObject]@{
                 From            = "releases/0.4";
                 To              = "releases/0.5";
@@ -140,7 +140,7 @@ Describe 'Get-AverageReleaseMetrics' {
                 ToDate          = [DateTime]"2019-06-04"
                 Interval        = New-Timespan -D 7;
                 IsFix           = $false;
-                MedianCommitAge = New-Timespan -D 4;}
+                CommitAges      = @(New-Timespan -D 4);}
             );        
 
         Mock Get-Date { return [DateTime]"2019-06-07"}

--- a/Tests/FourKeyMetrics.Tests.ps1
+++ b/Tests/FourKeyMetrics.Tests.ps1
@@ -13,11 +13,11 @@ Describe 'Check median calculations' {
                 $median | Should -Be 1.5 
             }
             It 'should work for 3 ordered values' {
-                $median = Get-Median @(New-TimeSpan -D 1; New-TimeSpan -D 2; New-TimeSpan -D 3)
+                $median = Get-Median @(New-TimeSpan -D 0; New-TimeSpan -D 2; New-TimeSpan -D 3)
                 $median | Should -Be 2
             }
             It 'should work for 3 unordered values' {
-                $median = Get-Median @(New-TimeSpan -D 2; New-TimeSpan -D 3; New-TimeSpan -D 1)
+                $median = Get-Median @(New-TimeSpan -D 2; New-TimeSpan -D 3; New-TimeSpan -D 0)
                 $median | Should -Be 2
             }
             It 'should work for 4 ordered values' {

--- a/Tests/FourKeyMetrics.Tests.ps1
+++ b/Tests/FourKeyMetrics.Tests.ps1
@@ -159,7 +159,7 @@ Describe 'Get-AverageReleaseMetrics' {
         It 'should provide averages looking back over the 14 day window' {
             $metrics | ForEach-Object { $_.Releases }                | Should -Be @(2,     3,    3,    1,    0    )
             $metrics | ForEach-Object { $_.DeploymentFrequencyDays } | Should -Be @(6.5,   5,    17,   42,   $null)
-            $metrics | ForEach-Object { $_.LeadTimeDays }            | Should -Be @(3,     2,    8,    20,   $null)
+            $metrics | ForEach-Object { $_.LeadTimeDays }            | Should -Be @(3,     2,    4,    20,   $null)
             $metrics | ForEach-Object { $_.FailRate }                | Should -Be @(0,    (1/3),(1/3), 0,    $null)
             $metrics | ForEach-Object { $_.MttrHours }               | Should -Be @($null, 24,   24,  $null, $null)
         }

--- a/Tests/FourKeyMetrics.Tests.ps1
+++ b/Tests/FourKeyMetrics.Tests.ps1
@@ -30,13 +30,13 @@ Describe 'Check median calculations' {
             }
     }
 }
-Describe 'Get-MetricsForPeriod' {
+Describe 'Get-BucketedMetricsForPeriod' {
     Context 'Given no releases' {
         $releases = @()
 
         $endDate = [DateTime]"2019-05-21";
 
-        $averageMetrics = Get-MetricsForPeriod $releases $endDate
+        $averageMetrics = Get-BucketedMetricsForPeriod $releases $endDate
 
         It 'should return an empty set of metrics' {
             $averageMetrics.Releases | Should -Be "0" # Explicitly provide zero releases
@@ -64,7 +64,7 @@ Describe 'Get-MetricsForPeriod' {
         It 'should return average metrics equal to the metrics of that release' {
             $endDate = [DateTime]"2019-05-17"
 
-            $averageMetrics = Get-MetricsForPeriod $releases $endDate
+            $averageMetrics = Get-BucketedMetricsForPeriod $releases $endDate
 
             $averageMetrics.Releases | Should -Be "1" # Explicitly provide one release
             $averageMetrics.DeploymentFrequencyDays | Should -Be "14" # Only 1 release, so the deployment frequency should be the same as the release interval
@@ -77,7 +77,7 @@ Describe 'Get-MetricsForPeriod' {
         It 'should not degrade the deployment frequency as time passes' {
             $endDate = [DateTime]"2019-05-21"
 
-            $averageMetrics = Get-MetricsForPeriod $releases $endDate
+            $averageMetrics = Get-BucketedMetricsForPeriod $releases $endDate
 
             $averageMetrics.Releases | Should -Be "1" # Explicitly provide one release
             $averageMetrics.DeploymentFrequencyDays | Should -Be "14" # Only 1 release, so the deployment frequency should be the same as the release interval
@@ -113,7 +113,7 @@ Describe 'Get-MetricsForPeriod' {
 
         $endDate = [DateTime]"2019-05-21"
 
-        $averageMetrics = Get-MetricsForPeriod $releases $endDate
+        $averageMetrics = Get-BucketedMetricsForPeriod $releases $endDate
 
         It 'should calculate the correct average metrics' {
             $averageMetrics.Releases | Should -Be "2" # Explicitly provide two releases

--- a/Tests/FourKeyMetrics.Tests.ps1
+++ b/Tests/FourKeyMetrics.Tests.ps1
@@ -28,7 +28,7 @@ Describe 'Get-MetricsForPeriod' {
             ToDate          = [DateTime]"2019-05-17";
             Interval        = New-Timespan -D 14;
             IsFix           = $false;
-            MedianCommitAge = New-Timespan -H 24;
+            CommitAges      = @(New-Timespan -H 24);
         }
     
         $releases = @($release)


### PR DESCRIPTION
This is stacked on https://github.com/red-gate/RedGate.Metrics/pull/18 (so do that one first)

The code used to go through the releases, and calculate some stats for each of them - in particular, the LeadTime which is the medium of the time diff between the date of each commit and the date of the release. 
Later we bucket the releases to graph them. A bucket has an end date and is 30 days wide - we find all releases in the bucket and then, in the case of LeadTime, we take the average of the lead times.

We shouldn't take the mean of the medians, but should just do a larger median calculation, taking all of the commit time diffs and doing a single median calculation on that. This PR changes the release objects to keep the list of time diffs, and then uses that to form a complete list of commits for all releases in the bucket.

We also add some tests on the median calculation.

For Sql Monitor, these are the current graphs and the graph after this change. The Lead Time gets a little narrower, and is a little higher.

![image](https://github.com/red-gate/RedGate.Metrics/assets/2143508/cd52ae31-35ac-41e6-ba3d-0e42c777657c)

![image](https://github.com/red-gate/RedGate.Metrics/assets/2143508/d3dc52df-2bff-4836-ae80-03b735c092fd)

I also changed the names of some variables and method to use `Bucketed` where we are putting things into buckets.