### PR TITLE
Allow filtering by teams when using a shared repo

### DIFF
--- a/Public/FourKeyMetrics.ps1
+++ b/Public/FourKeyMetrics.ps1
@@ -156,7 +156,7 @@ function global:Get-ReleaseMetrics {
     for ($i = 1; $i -lt $releases.Count; $i++) {
         $lastRelease = $releases[$i]
 
-        if (Assert-ReleaseShouldBeConsidered $ThisRelease.TagRef $ignoreReleases) {
+        if (Assert-ReleaseNotIgnored $ThisRelease.TagRef $ignoreReleases) {
             $CommitAges = Get-CommitsBetweenTags $lastRelease.TagRef $thisRelease.TagRef $subDirs $authors | Foreach-Object -Process { $thisRelease.Date - $_.Date } 
         }
         else {
@@ -181,7 +181,7 @@ function global:Get-ReleaseMetrics {
     }
 }
 
-function Assert-ReleaseShouldBeConsidered($thisReleaseTagRef, $ignoreReleases) {
+function Assert-ReleaseNotIgnored($thisReleaseTagRef, $ignoreReleases) {
     return !($ignoreReleases | Where-Object {$thisReleaseTagRef -Like "refs/tags/$_"})
 }
 

--- a/Public/FourKeyMetrics.ps1
+++ b/Public/FourKeyMetrics.ps1
@@ -163,7 +163,11 @@ function global:Get-ReleaseMetrics {
             $CommitAges = $null;
         }
 
-        [PSCustomObject]@{
+        if ($null -eq $CommitAges){
+            Write-Warning "Release $($thisRelease.TagRef) has no relevant commits and will be ignored"
+        }
+        else {
+            [PSCustomObject]@{
                 From             = $previousRelease.TagRef;
                 To               = $thisRelease.TagRef;
                 FromDate         = $previousRelease.Date;
@@ -171,6 +175,7 @@ function global:Get-ReleaseMetrics {
                 Interval         = $thisRelease.Date - $previousRelease.Date;
                 IsFix            = $thisRelease.IsFix;
                 CommitAges       = $CommitAges;
+            }
         }
 
         if ($previousRelease.Date -le $startDate) {

--- a/Public/FourKeyMetrics.ps1
+++ b/Public/FourKeyMetrics.ps1
@@ -154,30 +154,30 @@ function global:Get-ReleaseMetrics {
     )
     $thisRelease = $releases[0]
     for ($i = 1; $i -lt $releases.Count; $i++) {
-        $lastRelease = $releases[$i]
+        $previousRelease = $releases[$i]
 
         if (Assert-ReleaseNotIgnored $ThisRelease.TagRef $ignoreReleases) {
-            $CommitAges = Get-CommitsBetweenTags $lastRelease.TagRef $thisRelease.TagRef $subDirs $authors | Foreach-Object -Process { $thisRelease.Date - $_.Date } 
+            $CommitAges = Get-CommitsBetweenTags $previousRelease.TagRef $thisRelease.TagRef $subDirs $authors | Foreach-Object -Process { $thisRelease.Date - $_.Date } 
         }
         else {
             $CommitAges = $null;
         }
 
         [PSCustomObject]@{
-                From             = $lastRelease.TagRef;
+                From             = $previousRelease.TagRef;
                 To               = $thisRelease.TagRef;
-                FromDate         = $lastRelease.Date;
+                FromDate         = $previousRelease.Date;
                 ToDate           = $thisRelease.Date;
-                Interval         = $thisRelease.Date - $lastRelease.Date;
+                Interval         = $thisRelease.Date - $previousRelease.Date;
                 IsFix            = $thisRelease.IsFix;
                 CommitAges       = $CommitAges;
         }
 
-        if ($lastRelease.Date -le $startDate) {
+        if ($previousRelease.Date -le $startDate) {
             break
         }
 
-        $thisRelease = $lastRelease
+        $thisRelease = $previousRelease
     }
 }
 

--- a/Tests/FourKeyMetrics.Tests.ps1
+++ b/Tests/FourKeyMetrics.Tests.ps1
@@ -194,12 +194,12 @@ Describe 'Get-BucketedReleaseMetricsForReport' {
     }
 }
 
-Describe 'Assert-ReleaseShouldBeConsidered' {
+Describe 'Assert-ReleaseNotIgnored' {
     Context 'Given no releases should be ignored' {
         $ignoreReleases = @()
 
         It 'should return true for a given release' {
-            $val = Assert-ReleaseShouldBeConsidered "refs/tags/someTag" $ignoreReleases
+            $val = Assert-ReleaseNotIgnored "refs/tags/someTag" $ignoreReleases
             $val | Should -Be $true
         }
     }
@@ -207,12 +207,12 @@ Describe 'Assert-ReleaseShouldBeConsidered' {
         $ignoreReleases = @("releaseToIgnore")
 
         It 'should return false for a the ignored release' {
-            $val = Assert-ReleaseShouldBeConsidered "refs/tags/releaseToIgnore" $ignoreReleases
+            $val = Assert-ReleaseNotIgnored "refs/tags/releaseToIgnore" $ignoreReleases
             $val | Should -Be $false
         }
 
         It 'should return true for another release' {
-            $val = Assert-ReleaseShouldBeConsidered "refs/tags/someTag" $ignoreReleases
+            $val = Assert-ReleaseNotIgnored "refs/tags/someTag" $ignoreReleases
             $val | Should -Be $true
         }
     }
@@ -220,12 +220,12 @@ Describe 'Assert-ReleaseShouldBeConsidered' {
         $ignoreReleases = @("releaseToIgnore", "anotherReleaseToIgnore")
 
         It 'should return false for an ignored release' {
-            $val = Assert-ReleaseShouldBeConsidered "refs/tags/anotherReleaseToIgnore" $ignoreReleases
+            $val = Assert-ReleaseNotIgnored "refs/tags/anotherReleaseToIgnore" $ignoreReleases
             $val | Should -Be $false
         }
 
         It 'should return true for another release' {
-            $val = Assert-ReleaseShouldBeConsidered "refs/tags/someTag" $ignoreReleases
+            $val = Assert-ReleaseNotIgnored "refs/tags/someTag" $ignoreReleases
             $val | Should -Be $true
         }
     }


### PR DESCRIPTION
This use case has come up a few times, so I threw together a quick prototype.

**What's it for?**

We're increasingly seeing multiple teams working in a monorepo, or teams contributing across multiple repositories that are owned by other teams.

If we'd like these teams to see their performance (and potentially impact on changing working practices), we may need a new filtering mechanism.

**What's changed?**

This should:
* Accept an optional list of committer names (`authors`, in git terminology)
* When building a report we will:
  * Build a list of all releases for the repositories in question
  * Build a list of commits in each release, _only including commits by our listed authors_
  * _Throw away any releases that don't have commits by any of our authors_

(_Emphasis_ added for change in behaviour)

Behaviour when no list of committer names (or an empty list) is provided should be unchanged.

**Interesting edge cases**

*Automated commits (e.g. Renovate PRs)*
Currently we include the lead time, etc. of work done by tools like Renovate in our charts.
Whether this is desirable or not is debatable.
We can use this mechanism to explicitly include or exclude commits from these tools in our analysis.

*Occasional committers*
As with automated commits, our current reports will include any occasional commits in a repo that a team may (or may not) care about.
If a report is filtered to only consider committers of interest, that list needs to consider everyone of interest.

*People moving between teams*
If we care about performance before and after a team changes, we will need to include those past team members in our list of committers.
If someone moves from one team to another _but remains in the same monorepo_, we have no current way to differentiate between their work on Team A and their work on Team B.

*Working across multiple repositories*
I've processed a few reports locally, and they look like they make sense - only work from relevant folk was included in the report.
Logically this should be fine (at least as fine as any of our existing multi-product reports at Redgate are concerned), but I've little context to say if the results tell us what we'd expect.
