### PR TITLE
Spike bookmark: Show deviation from reported average

### DIFF
--- a/Public/FourKeyMetricsTemplate.html
+++ b/Public/FourKeyMetricsTemplate.html
@@ -16,7 +16,11 @@
         var data = new google.visualization.DataTable();
         data.addColumn("date", "EndDate");
         data.addColumn("number", "Deployment Frequency");
+        data.addColumn({type:"number", id:"i0", role:'interval'});
+        data.addColumn({type:"number", id:"i1", role:'interval'});
         data.addColumn("number", "Delivery Lead Time");
+        data.addColumn({type:"number", id:"i0", role:'interval'});
+        data.addColumn({type:"number", id:"i1", role:'interval'});
         data.addColumn("number", "Change Failure Rate");
         data.addColumn("number", "Mean Time to Recovery");
   
@@ -30,20 +34,22 @@
         ]);
   
         const charts = [
-          [1, "deploy-freq", "Days", "#336dc2"],
-          [2, "lead-time", "Days", "#128024"],
-          [3, "fail-rate", "Percent", "#c00", "percent"],
-          [4, "mttr", "Hours", "#fc9003"]
+          [1, 2, 3, "deploy-freq", "Days", "#336dc2"],
+          [4, 5, 6, "lead-time", "Days", "#128024"],
+          [7, 7, 7, "fail-rate", "Percent", "#c00", "percent"],
+          [8, 8, 8, "mttr", "Hours", "#fc9003"]
         ];
-  
+
         charts.forEach(c => {
-          const [colIndex, elementId, vAxisTitle, color, format] = c;
+          const [colIndex, lowColIndex, highColIndex, elementId, vAxisTitle, color, format] = c;
   
           var dataView = new google.visualization.DataView(data);
-          dataView.setColumns([0, colIndex]);
-          var chart = new google.visualization.LineChart(
+          dataView.setColumns([0, colIndex, lowColIndex, highColIndex]);
+
+          var chart = new google.visualization.ComboChart(
             document.getElementById(elementId).getElementsByClassName("content")[0]
           );
+
           chart.draw(dataView, {
             vAxis: { title: vAxisTitle, format, minValue: 0, maxValue: 1 },
             legend: { position: "none" },
@@ -52,7 +58,12 @@
             pointSize: 6,
             trendlines: { 0: { pointSize: 0 }},
             interpolateNulls: true,
-            hAxis: {minValue: REPORTSTARTDATE_PLACEHOLDER, maxValue: REPORTENDDATE_PLACEHOLDER}
+            hAxis: {minValue: REPORTSTARTDATE_PLACEHOLDER, maxValue: REPORTENDDATE_PLACEHOLDER},
+            curveType: 'function',
+            interval: {
+              'i0': { style:'area', color: color},
+              'i1': { style:'area', color: color}
+            }
           });
         });
       }

--- a/Tests/FourKeyMetrics.Tests.ps1
+++ b/Tests/FourKeyMetrics.Tests.ps1
@@ -104,7 +104,7 @@ Describe 'Get-BucketedMetricsForPeriod' {
             ToDate          = [DateTime]"2019-05-21"
             Interval        = New-Timespan -D 4;
             IsFix           = $true;
-            CommitAges      = @(New-Timespan -H 24);
+            CommitAges      = @(New-Timespan -H 12);
         }
         
         $releaseOne = [PSCustomObject]@{
@@ -114,7 +114,7 @@ Describe 'Get-BucketedMetricsForPeriod' {
             ToDate          = [DateTime]"2019-05-17"
             Interval        = New-Timespan -D 1;
             IsFix           = $false;
-            CommitAges      = @(New-Timespan -H 24);
+            CommitAges      = @(New-Timespan -H 36);
         }
     
         $releases = @($releaseTwo, $releaseOne)
@@ -130,8 +130,8 @@ Describe 'Get-BucketedMetricsForPeriod' {
             $bucketedMetrics.DeploymentFrequencyHigh | Should -Be "4"
             $bucketedMetrics.MttrHours | Should -Be 96 # Single recovery took four whole days
             $bucketedMetrics.LeadTimeDays | Should -Be "1" # Both releases have a lead time of one day
-            $bucketedMetrics.LeadTimeLow | Should -Be "1"
-            $bucketedMetrics.LeadTimeHigh | Should -Be "1"
+            $bucketedMetrics.LeadTimeLow | Should -Be "0.5"
+            $bucketedMetrics.LeadTimeHigh | Should -Be "1.5"
             $bucketedMetrics.FailRate | Should -Be "0.5" # One of two releases was a failure
             $bucketedMetrics.EndDate | Should -Be $endDate
         }

--- a/Tests/FourKeyMetrics.Tests.ps1
+++ b/Tests/FourKeyMetrics.Tests.ps1
@@ -41,8 +41,12 @@ Describe 'Get-BucketedMetricsForPeriod' {
         It 'should return an empty set of metrics' {
             $bucketedMetrics.Releases | Should -Be "0" # Explicitly provide zero releases
             $bucketedMetrics.DeploymentFrequencyDays | Should -Be $null
+            $bucketedMetrics.DeploymentFrequencyLow | Should -Be $null
+            $bucketedMetrics.DeploymentFrequencyHigh | Should -Be $null
             $bucketedMetrics.MttrHours | Should -Be $null
             $bucketedMetrics.LeadTimeDays | Should -Be $null
+            $bucketedMetrics.LeadTimeLow | Should -Be $null
+            $bucketedMetrics.LeadTimeHigh | Should -Be $null
             $bucketedMetrics.FailRate | Should -Be $null
             $bucketedMetrics.EndDate | Should -Be $endDate
         }
@@ -68,8 +72,12 @@ Describe 'Get-BucketedMetricsForPeriod' {
 
             $bucketedMetrics.Releases | Should -Be "1" # Explicitly provide one release
             $bucketedMetrics.DeploymentFrequencyDays | Should -Be "14" # Only 1 release, so the deployment frequency should be the same as the release interval
+            $bucketedMetrics.DeploymentFrequencyHigh | Should -Be "14"
+            $bucketedMetrics.DeploymentFrequencyLow | Should -Be "14"
             $bucketedMetrics.MttrHours | Should -Be $null # No recoveries in the provided dataset
             $bucketedMetrics.LeadTimeDays | Should -Be "1" # Release has a lead time of one day
+            $bucketedMetrics.LeadTimeLow | Should -Be "1"
+            $bucketedMetrics.LeadTimeHigh | Should -Be "1"
             $bucketedMetrics.FailRate | Should -Be "0" # No failures
             $bucketedMetrics.EndDate | Should -Be $endDate
         }
@@ -118,8 +126,12 @@ Describe 'Get-BucketedMetricsForPeriod' {
         It 'should calculate the correct bucketed metrics' {
             $bucketedMetrics.Releases | Should -Be "2" # Explicitly provide two releases
             $bucketedMetrics.DeploymentFrequencyDays | Should -Be "2.5" # Release intervals were 1 and 4, so average is 2.5
+            $bucketedMetrics.DeploymentFrequencyLow | Should -Be "1"
+            $bucketedMetrics.DeploymentFrequencyHigh | Should -Be "4"
             $bucketedMetrics.MttrHours | Should -Be 96 # Single recovery took four whole days
             $bucketedMetrics.LeadTimeDays | Should -Be "1" # Both releases have a lead time of one day
+            $bucketedMetrics.LeadTimeLow | Should -Be "1"
+            $bucketedMetrics.LeadTimeHigh | Should -Be "1"
             $bucketedMetrics.FailRate | Should -Be "0.5" # One of two releases was a failure
             $bucketedMetrics.EndDate | Should -Be $endDate
         }


### PR DESCRIPTION
Some folk are interested in more context around the averaged values these charts show - specifically, how far can we expect these metrics to stray from their reported averages? Just _what_ are those averages hiding?

Spent a little time hacking away and got this far:

![image](https://github.com/red-gate/RedGate.Metrics/assets/8382756/dd38eea1-ae9e-44c0-924b-84639fa6d7be)

Recording this work on a draft PR to keep my notes close to the work, but anyone's welcome to comment if they're interested.

Some shenanigans to remember if I come back to this.

**Maths**
Deviation is _not_ standardised here! We're pulling through actual high/low values that feed in to the averaged data points, and visualising those.

**Google charts choices**
This is using the _intervals_ feature of Google Charts line charts - in fact, it's a suggested use case for that feature.

There are other visualisation options, which may help with a problem below, but I like this one.

**MTTR**
Applying the same pattern to MTTR feels doable, but I hit an error rendering the chart - I think this is due to having _no_ MTTR data in the chart I was testing against, but haven't confirmed this hypothesis.

The error isn't exactly helpful, but my guess is we're asking to draw an area with no vertices, and that's causing issues. 

If that's true, any chart (with this deviation interval _thing_) will fail to render if there are no data points at all.

This is different behaviour from current charts having no data at all, as shown by the current MTTR charts.

**CFR**
Not sure how this pattern can be (meaningfully) applied to CFR, since it's already a proportional measure - something like a candlestick visualisation could be relevant, but is it useful?

***Y Axis***
I've occasionally had the minimum value on the Y-Axis go below 0 with these changes in place - not looked into why, but I should!

**Data bloat, graph crowding, and future direction**
This relies on cramming more data into our existing `BucketedMetrics` - I think that's OK, but does feel a bit icky.

It also makes the charts somewhat noisier. How easy would it be to make showing deviation data optional? Relevant SO link: https://stackoverflow.com/questions/72010311/show-hide-toggle-data-series-on-google-chart-by-clicking-legend

I've also looked into adding chart areas to show performance against whatever the latest State of DevOps report considers 'high' performance (etc.). Having that info _and_ this on the same chart could become difficult to read. Worth considering options here.